### PR TITLE
Test if IntersectionObserver API available

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -405,7 +405,9 @@ export class EmojiButton {
       this.options.rootElement.appendChild(this.wrapper);
     }
 
-    this.observeForLazyLoad();
+    if ('IntersectionObserver' in window) {
+      this.observeForLazyLoad();
+    }
   }
 
   /**


### PR DESCRIPTION
Simple update to make sure that `IntersectionObserver` is available so that older clients (< Safari 12, Firefox 54) or clients that have disabled
`IntersectionObserver` do not throw errors and crash the app.