### PR TITLE
Adds support for a custom data object for custom emojis

### DIFF
--- a/site/src/examples/custom/custom.js
+++ b/site/src/examples/custom/custom.js
@@ -6,7 +6,11 @@ const picker = new EmojiButton({
   custom: [
     {
       name: 'Conga parrot',
-      emoji: './site/static/conga_parrot.gif'
+      emoji: './site/static/conga_parrot.gif',
+      customData: {
+        'foo': 'bar',
+        'id': 3
+      }
     },
     {
       name: 'O RLY?',

--- a/site/src/pages/docs/custom.js
+++ b/site/src/pages/docs/custom.js
@@ -42,6 +42,9 @@ export default function CustomExample() {
         <li>
           <code>emoji</code>: The URL of the image to use for the custom emoji
         </li>
+        <li>
+          <code>customData</code>: An object containing any custom data you might wanna get back when selecting the emoji
+        </li>
       </ul>
 
       <p>

--- a/src/index.ts
+++ b/src/index.ts
@@ -273,6 +273,7 @@ export class EmojiButton {
     return {
       url: emoji.emoji,
       name: emoji.name,
+      customData: emoji.customData,
       custom: true
     };
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export interface EmojiRecord {
   version?: string;
   variations?: string[];
   key?: string;
+  customData?: object;
 }
 
 export interface EmojiData {
@@ -22,6 +23,7 @@ export interface EmojiSelection {
   custom?: boolean;
   emoji?: string;
   url?: string;
+  customData?: object;
 }
 
 export interface RecentEmoji {


### PR DESCRIPTION
This PR adds a `customData` object to custom emojis, like so:

```js
const picker = new EmojiButton({
    custom: [
        {
            name: 'Apple',
            emoji: './img/apple.png',
            customData: {
                foo: 'bar',
                id: 3
            }
        }
    ]
});

picker.on('emoji', selection => {
    console.log(selection);
});
```

This will also return all the e extra info under `selection.customData` when selecting an emoji.

## Why is this useful?

well, it's useful to return any data you might wanna set for custom emojis. In my use case, I have a database with all my custom emojis, and each emoji has an ID. I wanted to get the ID back when the user selects an emoji, so I can use it somewhere else.