### PR TITLE
Fix typo in documentation example for "provided static data"

### DIFF
--- a/docs/docs/02 - usage/06 - emoji-data.md
+++ b/docs/docs/02 - usage/06 - emoji-data.md
@@ -24,7 +24,7 @@ import messages from 'emojibase-data/<locale>/messages.json';
 
 const picker = createPicker({
   emojiData,
-  message
+  messages
 });
 ```
 


### PR DESCRIPTION
While reviewing the documentation, I found a typo in an example. 

If you actually configure `createPicker` with the parameter as the documentation says, you'll have a `message is not defined` exception. 

This PR fixes the typo.